### PR TITLE
Fix to match color from code and from IB

### DIFF
--- a/RMRHexColorGen/Classes/Helper/NSColorList+RMRHexColor.m
+++ b/RMRHexColorGen/Classes/Helper/NSColorList+RMRHexColor.m
@@ -27,6 +27,15 @@
         NSColor *color = [NSColor colorWithHexString:hexColor.colorValue];
         NSString *colorName =
             [prefix stringByAppendingString:[hexColor.colorTitle RMR_uppercaseFisrtSymbol]];
+        
+        CGFloat red = [color redComponent];
+        CGFloat green = [color greenComponent];
+        CGFloat blue = [color blueComponent];
+        CGFloat alpha = [color alphaComponent];
+        color = [NSColor colorWithCalibratedRed:red
+                                          green:green
+                                           blue:blue
+                                          alpha:alpha];
 
         [self setColor:color forKey:colorName];
     }

--- a/RMRRefreshColorPanelPlugin/Info.plist
+++ b/RMRRefreshColorPanelPlugin/Info.plist
@@ -28,6 +28,7 @@
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>


### PR DESCRIPTION
Seems like IB use colors in genericRGB, but iOs loads same color components as sRGB.
